### PR TITLE
fix: make UUID retrieval more portable

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -373,7 +373,7 @@ impl Device {
     /// ```
     pub fn uuid(self) -> CudaResult<[u8; 16]> {
         unsafe {
-            let mut cu_uuid = CUuuid { bytes: [0i8; 16] };
+            let mut cu_uuid = CUuuid { bytes: [0; 16] };
             cuDeviceGetUuid(&mut cu_uuid, self.device).to_result()?;
             let uuid: [u8; 16] = ::std::mem::transmute(cu_uuid.bytes);
             Ok(uuid)


### PR DESCRIPTION
The `CUuuid` byte type is `std::os::raw::c_char` and it depends on the platform, whether it is `i8` or `u8` in Rust. With just passing in `0` without a type identifier, both cases are handled. This makes the code more portable.

This is needed when CUDA things are compiled on ARM.